### PR TITLE
Add ability to install native-image

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,7 +45,10 @@ jobs:
           - 19.3.1.java11
           - 20.0.0.java8
           - 20.0.0.java11
-    name: functionalTest ${{ matrix.graal }}
+        nativeImage:
+          - installed
+          - "uninstalled"
+    name: "functionalTest ${{ matrix.graal }}(native-image: ${{ matrix.nativeImage }})"
 
     steps:
       - name: Checkout
@@ -56,8 +59,14 @@ jobs:
         with:
           graalvm-version: ${{ matrix.graal }}
 
+      - name: show gu command
+        run: |
+          which gu
+          echo $JAVA_HOME
+
       - name: Install GraalVM native-image
         run: gu install native-image
+        if: "startsWith(matrix.nativeImage, 'installed')"
 
       - name: Cache gradle
         id: gradle
@@ -74,7 +83,7 @@ jobs:
         uses: actions/upload-artifact@v1
         if: always()
         with:
-          name: test-report-${{ matrix.graal }}
+          name: test-report-${{ matrix.graal }}-${{ matrix.nativeImage }}
           path: build/reports/tests/functionalTest
 
   oldGraalFunctionalTest:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,16 +39,16 @@ jobs:
     strategy:
       matrix:
         graal:
-          - 19.3.0.java8
-          - 19.3.0.java11
-          - 19.3.1.java8
-          - 19.3.1.java11
-          - 20.0.0.java8
-          - 20.0.0.java11
+          - 19.3.0
+          - 19.3.1
+          - 20.0.0
+        javaVersion:
+          - java8
+          - java11
         nativeImage:
           - installed
           - "uninstalled"
-    name: "functionalTest ${{ matrix.graal }}(native-image: ${{ matrix.nativeImage }})"
+    name: "test ${{ matrix.graal }}.${{ matrix.javaVersion }}(native-image: ${{ matrix.nativeImage }})"
 
     steps:
       - name: Checkout
@@ -57,7 +57,7 @@ jobs:
       - name: Set up GraalVM
         uses: DeLaGuardo/setup-graalvm@2.0
         with:
-          graalvm-version: ${{ matrix.graal }}
+          graalvm-version: "${{ matrix.graal }}.${{ matrix.javaVersion }}"
 
       - name: show gu command
         run: |
@@ -83,13 +83,19 @@ jobs:
         uses: actions/upload-artifact@v1
         if: always()
         with:
-          name: test-report-${{ matrix.graal }}-${{ matrix.nativeImage }}
+          name: test-report-${{ matrix.graal }}-${{ matrix.javaVersion }}-${{ matrix.nativeImage }}
           path: build/reports/tests/functionalTest
 
   oldGraalFunctionalTest:
     runs-on: ubuntu-18.04
     needs: functionalTest
-    name: functionalTest on graalvm 19.2.1
+    name: test on graalvm 19.2.1
+    strategy:
+      matrix:
+        nativeImage:
+          - installed
+          - "uninstalled"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -117,5 +123,5 @@ jobs:
         uses: actions/upload-artifact@v1
         if: always()
         with:
-          name: test-report-19.2.1
+          name: test-report-19.2.1-${{ matrix.nativeImage }}
           path: build/reports/tests/functionalTest

--- a/src/functionalTest/resources/java-project/build-gradle-output-directory.txt
+++ b/src/functionalTest/resources/java-project/build-gradle-output-directory.txt
@@ -12,7 +12,7 @@ dependencies {
 }
 
 nativeImage {
-  graalVmHome = System.getProperty('java.home')
+  graalVmHome = System.getenv('JAVA_HOME')
   mainClass = 'com.example.App'
   executableName = 'test-app'
   outputDirectory = file("$buildDir/executable")

--- a/src/functionalTest/resources/java-project/build-gradle.txt
+++ b/src/functionalTest/resources/java-project/build-gradle.txt
@@ -12,7 +12,7 @@ dependencies {
 }
 
 nativeImage {
-  graalVmHome = System.getProperty('java.home')
+  graalVmHome = System.getenv('JAVA_HOME')
   mainClass = 'com.example.App'
   executableName = 'test-app'
   arguments('--no-fallback')

--- a/src/functionalTest/resources/kotlin-project/build-gradle-kts.txt
+++ b/src/functionalTest/resources/kotlin-project/build-gradle-kts.txt
@@ -21,7 +21,7 @@ application {
 }
 
 nativeImage {
-  setGraalVmHome(System.getProperty("java.home"))
+  setGraalVmHome(System.getenv("JAVA_HOME"))
   setMainClass("com.example.AppKt")
   setExecutableName("test-app")
   arguments("--no-fallback")

--- a/src/main/java/org/mikeneck/graalvm/GraalVmHome.java
+++ b/src/main/java/org/mikeneck/graalvm/GraalVmHome.java
@@ -29,6 +29,28 @@ class GraalVmHome {
         graalVmHome = home;
     }
 
+    boolean notFound() {
+        return !exists();
+    }
+
+    boolean exists() {
+        return Files.exists(graalVmHome);
+    }
+
+    Optional<Path> graalVmUpdater() {
+        return graalVmUpdaterCandidates()
+                .stream()
+                .filter(Files::exists)
+                .findFirst();
+    }
+
+    private List<Path> graalVmUpdaterCandidates() {
+        return Arrays.asList(
+                graalVmHome.resolve("bin/gu"),
+                graalVmHome.resolve("bin/gu.cmd")
+        );
+    }
+
     Optional<Path> nativeImage() {
         return nativeImageCandidates()
                 .stream()

--- a/src/main/java/org/mikeneck/graalvm/GraalvmNativeImagePlugin.java
+++ b/src/main/java/org/mikeneck/graalvm/GraalvmNativeImagePlugin.java
@@ -3,8 +3,8 @@
  */
 package org.mikeneck.graalvm;
 
-import org.gradle.api.Project;
 import org.gradle.api.Plugin;
+import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskContainer;
 import org.jetbrains.annotations.NotNull;
 
@@ -15,11 +15,19 @@ public class GraalvmNativeImagePlugin implements Plugin<Project> {
         project.getExtensions().add("nativeImage", nativeImageExtension);
 
         TaskContainer taskContainer = project.getTasks();
+
+        InstallNativeImageTask installNativeImageTask = taskContainer.create(
+                "installNativeImage", InstallNativeImageTask.class, project);
+        installNativeImageTask.setExtension(nativeImageExtension);
+        installNativeImageTask.setDescription("Installs native-image command by graalVm Updater command");
+        installNativeImageTask.setGroup("graalvm");
+
         taskContainer.create("nativeImage", NativeImageTask.class, task -> {
             task.setExtension(nativeImageExtension);
             task.dependsOn("jar");
             task.setDescription("Creates native executable");
             task.setGroup("graalvm");
+            task.dependsOn(installNativeImageTask);
         });
     }
 }

--- a/src/main/java/org/mikeneck/graalvm/InstallNativeImageTask.java
+++ b/src/main/java/org/mikeneck/graalvm/InstallNativeImageTask.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Shinya Mochida
+ *
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mikeneck.graalvm;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import javax.inject.Inject;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.StopExecutionException;
+import org.gradle.api.tasks.TaskAction;
+
+public class InstallNativeImageTask extends DefaultTask {
+
+    private final Property<NativeImageExtension> extension;
+
+    @Inject
+    public InstallNativeImageTask(Project project) {
+        this.extension = project.getObjects().property(NativeImageExtension.class);
+    }
+
+    void setExtension(NativeImageExtension extension) {
+        this.extension.set(extension);
+    }
+
+    @TaskAction
+    public void installNativeImage() {
+        GraalVmHome graalVmHome = graalVmHome();
+        if (graalVmHome.notFound()) {
+            getLogger().info("GRAALVM_HOME[{}] not found", graalVmHome);
+            throw new InvalidUserDataException(String.format("graalVM not found at %s", graalVmHome));
+        }
+        Optional<Path> nativeImageCommand = nativeImageCommand();
+        if (nativeImageCommand.isPresent()) {
+            Path nativeImage = nativeImageCommand.get();
+            getLogger().info("native-image command exists: {}", nativeImage);
+            throw new StopExecutionException(
+                    String.format("native-image command exists at %s", nativeImage));
+        }
+        Path graalVmUpdaterCommand = graalVmUpdaterCommand()
+                .orElseThrow(() -> new InvalidUserDataException(
+                        String.format("graalVM updater command does not exist in %s.", graalVmHome)));
+        getLogger().info("found graalVM updater command: {}", graalVmUpdaterCommand);
+        getProject().exec(execSpec -> {
+            execSpec.setExecutable(graalVmUpdaterCommand);
+            execSpec.args("install", "native-image");
+        });
+    }
+
+    private GraalVmHome graalVmHome() {
+        return extension.get().graalVmHome();
+    }
+
+    Optional<Path> graalVmUpdaterCommand() {
+        return graalVmHome().graalVmUpdater();
+    }
+
+    Optional<Path> nativeImageCommand() {
+        return graalVmHome().nativeImage();
+    }
+}


### PR DESCRIPTION
Fix #25 

Changes
---

- Add `InstallNativeImageTask` that invokes `gu install native-image`
    - `InstallNativeImageTask` will be executed when `native-image` is not found under configured `graalVmHome`.
    - It runs `gu install native-image` the executable of which is in the configured `graalVmHome`.
- Add `InstallNativeImageTask` type task `installNativeImage`
- Make `nativeImage` task depends on `installNativeImage` task.


