### PR TITLE
Make generateNativeImageConfig to depend on installNativeImage

### DIFF
--- a/src/functionalTest/java/org/mikeneck/graalvm/GenerateConfigFileTaskTest.java
+++ b/src/functionalTest/java/org/mikeneck/graalvm/GenerateConfigFileTaskTest.java
@@ -105,4 +105,29 @@ class GenerateConfigFileTaskTest {
         assertThat(nativeImageResult).isEqualTo(TaskOutcome.SUCCESS);
         assertTrue(Files.exists(projectDir.resolve("build/tmp/native-image-config/out-2")));
     }
+
+    @Test
+    void dryRunNativeImageConfig() {
+        FunctionalTestContext context = new FunctionalTestContext("config-project", "config-project-dry-run");
+        context.setup();
+        Path projectDir = context.rootDir;
+
+        GradleRunner runner = GradleRunner.create();
+        runner.forwardOutput();
+        runner.withPluginClasspath();
+        runner.withArguments("generateNativeImageConfig", "--dry-run");
+        runner.withProjectDir(projectDir.toFile());
+        BuildResult result = runner.build();
+
+        String succeededTasks = result.getOutput();
+
+        assertThat(succeededTasks).contains(
+                ":installNativeImage SKIPPED",
+                ":compileJava SKIPPED",
+                ":processResources SKIPPED",
+                ":classes SKIPPED",
+                ":jar SKIPPED",
+                ":generateNativeImageConfig SKIPPED",
+                ":mergeNativeImageConfig SKIPPED");
+    }
 }

--- a/src/main/java/org/mikeneck/graalvm/GraalvmNativeImagePlugin.java
+++ b/src/main/java/org/mikeneck/graalvm/GraalvmNativeImagePlugin.java
@@ -26,6 +26,7 @@ public class GraalvmNativeImagePlugin implements Plugin<Project> {
         GenerateNativeImageConfigTask nativeImageConfigFiles = taskFactory.nativeImageConfigFilesTask(task -> {
             task.setGroup("graalvm");
             task.setDescription("Generates native image config json files via test run.");
+            task.dependsOn(installNativeImageTask);
         });
 
         MergeNativeImageConfigTask mergeNativeImageConfigTask = taskFactory.mergeNativeImageConfigTask(task -> {


### PR DESCRIPTION
Fix #52 

- Add `dependsOn` configuration to generateNativeImageConfig task.
- Add test of dry-running `generateNativeImageConfig` which verifies installNativeImage task to run.
