### PR TITLE
Update GraalVM version from 20.1.0 to 20.2.0

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v1.3.0
         with:
-          java-version: '8.0.242'
+          java-version: '8.0.265'
 
       - name: Cache gradle
         id: gradle
@@ -40,7 +40,7 @@ jobs:
       matrix:
         graal:
           - 19.3.3
-          - 20.1.0
+          - 20.2.0
         javaVersion:
           - java8
           - java11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v1.3.0
         with:
-          java-version: '8.0.242'
+          java-version: '8.0.265'
 
       - name: Cache gradle
         id: gradle

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up GraalVM
         uses: DeLaGuardo/setup-graalvm@2.0
         with:
-          graalvm-version: 20.1.0.java11
+          graalvm-version: 20.2.0.java11
 
       - name: Install GraalVM native-image
         run: gu install native-image


### PR DESCRIPTION
Fix #77 

- in `versions.yml` use GraalVM version 20.2.0.java11
- in `gradle.yml` use GraalVM version 20.2.0 instead of 20.1.0
- in `gradle.yml` use Java 8.0.265 instead of 8.0.242
- in `release.yml` use Java 8.0.265 instead of 8.0.242