### PR TITLE
use mavenCentral instead of jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ group = 'org.mikeneck'
 version = thisPluginVersion
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 sourceSets {


### PR DESCRIPTION
JCenter is going to be shutdown. https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/