### PR TITLE
Fix `Gradle Kotlin DSL` part of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ dependencies {
 nativeImage {
     graalVmHome = System.getenv("JAVA_HOME")
     mainClass ="com.example.App" // Deprecated, use `buildType.executable.main` as follows instead.
-    buildType {
-      executable(main = 'com.example.App')
+    buildType { build ->
+      build.executable(main = 'com.example.App')
     }
     executableName = "my-native-application"
     outputDirectory = file("$buildDir/executable")


### PR DESCRIPTION
As a separate issue: if I leave `mainClass` from my kotlin build I get the following error:

```
> Task :generateNativeImageConfig FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Some problems were found with the configuration of task ':generateNativeImageConfig' (type 'DefaultGenerateNativeImageConfigTask').
  - Type 'org.mikeneck.graalvm.DefaultGenerateNativeImageConfigTask' property 'javaExecutions.$0.mainClass' doesn't have a configured value.

    Reason: This property isn't marked as optional and no value has been configured.

    Possible solutions:
      1. Assign a value to 'javaExecutions.$0.mainClass'.
      2. Mark property 'javaExecutions.$0.mainClass' as optional.

    Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#value_not_set for more details about this problem.
...
```