### PR TITLE
Reproduce and fix 175

### DIFF
--- a/src/functionalTest/java/org/mikeneck/graalvm/Case175WithoutMainClass.java
+++ b/src/functionalTest/java/org/mikeneck/graalvm/Case175WithoutMainClass.java
@@ -1,0 +1,26 @@
+package org.mikeneck.graalvm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * @see <a href="https://github.com/mike-neck/graalvm-native-image-plugin/issues/175">GitHub
+ *     Issue</a>
+ */
+class Case175WithoutMainClass {
+
+  @Test
+  @ExtendWith(TestProjectSetup.class)
+  @TestProject(value = "case-175-without-mainclass")
+  void run(@NotNull Gradlew gradlew, @NotNull FunctionalTestContext context) {
+    BuildResult result = gradlew.invoke("nativeImage", "--info");
+    assertThat(result.tasks(TaskOutcome.SUCCESS).stream().map(BuildTask::getPath))
+        .contains(":nativeImage");
+  }
+}

--- a/src/functionalTest/resources/case-175-without-mainclass/build-gradle-kts.txt
+++ b/src/functionalTest/resources/case-175-without-mainclass/build-gradle-kts.txt
@@ -1,0 +1,26 @@
+plugins {
+  `java`
+  id("org.mikeneck.graalvm-native-image")
+}
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation("org.slf4j:slf4j-simple:1.7.28")
+}
+
+nativeImage {
+  graalVmHome = System.getenv("JAVA_HOME")
+  buildType { build ->
+    build.executable(main = "com.example.App")
+  }
+  executableName = "test-app"
+  arguments("--no-fallback")
+}
+
+generateNativeImageConfig {
+  enabled = true
+  byRunningApplicationWithoutArguments()
+}

--- a/src/functionalTest/resources/case-175-without-mainclass/src_main_java_com_example_App-java.txt
+++ b/src/functionalTest/resources/case-175-without-mainclass/src_main_java_com_example_App-java.txt
@@ -1,0 +1,11 @@
+package com.example;
+
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+
+public class App {
+  static final Logger logger = LoggerFactory.getLogger(App.class);
+  public static void main(String... args) {
+    logger.info("Hello");
+  }
+}

--- a/src/main/java/org/mikeneck/graalvm/GenerateNativeImageConfigTask.java
+++ b/src/main/java/org/mikeneck/graalvm/GenerateNativeImageConfigTask.java
@@ -10,6 +10,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.jetbrains.annotations.NotNull;
 
@@ -40,6 +41,7 @@ public interface GenerateNativeImageConfigTask extends ShareEnabledState {
   boolean getExitOnApplicationError();
 
   @Input
+  @Optional
   @NotNull
   Provider<String> getMainClass();
 


### PR DESCRIPTION
Thanks for sharing your great Gradle plugin, it helped me a lot to challenge `native-image`!

By this PR I want to suggest a fix for #175. Refer to [this workflow run](https://github.com/KengoTODA/graalvm-native-image-plugin/actions/runs/1431599290) to confirm that the test case surely reproduces the reported issue.
Note that this fix expects that the Gradle project always have only one `NativeImageTask` type task, to refer a property (buildType) of `NativeImageTask` from `GenerateNativeImageConfigTask`.