### PR TITLE
Fix Kotlin build script in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Example
 ```groovy
 plugins {
   id 'java'
-  id 'org.mikeneck.graalvm-native-image' version 'v1.4.0'
+  id 'org.mikeneck.graalvm-native-image' version '1.4.1'
 }
 
 repositories {
@@ -109,7 +109,7 @@ import org.mikeneck.graalvm.GenerateNativeImageConfigTask
 
 plugins {
   kotlin("jvm") version "1.3.72"
-  id("org.mikeneck.graalvm-native-image") version "v1.4.0"
+  id("org.mikeneck.graalvm-native-image") version "1.4.1"
 }
 
 repositories {
@@ -162,7 +162,7 @@ Shared library feature is one of GraalVM's feature to build shared library('so' 
 ```groovy
 plugins {
   id 'java'
-  id 'org.mikeneck.graalvm-native-image' version 'v1.4.0'
+  id 'org.mikeneck.graalvm-native-image' version '1.4.1'
 }
 
 repositories {
@@ -216,7 +216,7 @@ import org.mikeneck.graalvm.GenerateNativeImageConfigTask
 
 plugins {
   kotlin("jvm") version "1.3.72"
-  id("org.mikeneck.graalvm-native-image") version "v1.4.0"
+  id("org.mikeneck.graalvm-native-image") version "1.4.1"
 }
 
 repositories {

--- a/README.md
+++ b/README.md
@@ -124,17 +124,17 @@ nativeImage {
     graalVmHome = System.getenv("JAVA_HOME")
     mainClass ="com.example.App" // Deprecated, use `buildType.executable.main` as follows instead.
     buildType { build ->
-      build.executable(main = 'com.example.App')
+      build.executable(main = "com.example.App")
     }
     executableName = "my-native-application"
     outputDirectory = file("$buildDir/executable")
-    arguments(
+    arguments(*arrayOf(
         "--no-fallback",
         "--enable-all-security-services",
-        options.traceClassInitialization('com.example.MyDataProvider,com.example.MyDataConsumer'),
+        options.traceClassInitialization("com.example.MyDataProvider,com.example.MyDataConsumer"),
         "--initialize-at-run-time=com.example.runtime",
         "--report-unsupported-elements-at-runtime"
-    )
+    ))
 }
 
 generateNativeImageConfig {
@@ -149,7 +149,7 @@ generateNativeImageConfig {
   }
   byRunningApplicationWithoutArguments()
   byRunningApplication {
-    arguments('-h')
+    arguments("-h")
   }
 }
 ```
@@ -229,16 +229,18 @@ dependencies {
 
 nativeImage {
     graalVmHome = System.getenv("JAVA_HOME")
-    buildType { sharedLibrary }
+    buildType { build ->
+        build.sharedLibrary
+    }
     executableName = "my-native-lib"
     outputDirectory = file("$buildDir/native-lib")
-    arguments(
+    arguments(*arrayOf(
         "--no-fallback",
         "--enable-all-security-services",
-        options.traceClassInitialization('com.example.MyDataProvider,com.example.MyDataConsumer'),
+        options.traceClassInitialization("com.example.MyDataProvider,com.example.MyDataConsumer"),
         "--initialize-at-run-time=com.example.runtime",
         "--report-unsupported-elements-at-runtime"
-    )
+    ))
 }
 
 generateNativeImageConfig {
@@ -255,7 +257,7 @@ generateNativeImageConfig {
   }
   byRunningApplicationWithoutArguments()
   byRunningApplication {
-    arguments('-h')
+    arguments("-h")
   }
 }
 ```


### PR DESCRIPTION
This PR suggests fixing the following issues in README:

1. According to [plugin portal](https://plugins.gradle.org/plugin/org.mikeneck.graalvm-native-image/1.4.1) the plugin version in the build script should be not `vMAJOR.MINOR.PATCH` but `MAJOR.MINOR.PATCH`.
2. Kotlin uses double quote to represent `String` literal.
3. To invoke methods with vararg, need to use a spread operator (`*`).

