### PR TITLE
Fix build failures in PRs created by auto-update-versions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -99,7 +99,7 @@ jobs:
         if: "${{ 'java16' == matrix.javaVersion }}"
         run: sed -i -r "/org.jetbrains.kotlin.jvm/s/[0-9]+\.[0-9]+\.[0-9]+/${KOTLIN_VERSION_FOR_GRADLE_7}/g" ./build.gradle
         env:
-          KOTLIN_VERSION_FOR_GRADLE_7: "1.4.31"
+          KOTLIN_VERSION_FOR_GRADLE_7: "1.5.31"
 
       - name: Show JAVA_HOME contents
         run: |

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -101,6 +101,12 @@ jobs:
         env:
           KOTLIN_VERSION_FOR_GRADLE_7: "1.5.31"
 
+      - name: Override shadow plugin version if Java16
+        if: "${{ 'java16' == matrix.javaVersion }}"
+        run: sed -i -r "/com.github.johnrengelman.shadow/s/[0-9]+\.[0-9]+\.[0-9]+/${SHADOW_PLUGIN_VERSION_FOR_GRADLE_7}/g" ./build.gradle
+        env:
+          SHADOW_PLUGIN_VERSION_FOR_GRADLE_7: "7.1.0"
+
       - name: Show JAVA_HOME contents
         run: |
           echo "${JAVA_HOME}"


### PR DESCRIPTION
This PR will merge two changes into #180, to fix build failures in its branch.
There is no fix for the product itself, just update Gradle plugin versions to build with Gradle 7 and Java 16.