### PR TITLE
Add four new fields to ClassUsage

### DIFF
--- a/src/main/java/org/mikeneck/graalvm/GraalVmVersion.java
+++ b/src/main/java/org/mikeneck/graalvm/GraalVmVersion.java
@@ -32,6 +32,16 @@ public enum GraalVmVersion {
   GRAAL_21_1_0_JAVA_8("21.1.0-java8", new GraalVm21Matcher("21.1.0", "java8")),
   GRAAL_21_1_0_JAVA_11("21.1.0-java11", new GraalVm21Matcher("21.1.0", "java11")),
   GRAAL_21_1_0_JAVA_16("21.1.0-java16", new GraalVm21Matcher("21.1.0", "java16")),
+  GRAAL_20_3_3_JAVA_8("20.3.3-java8", new GraalVm20Matcher("20.3.3", "java8")),
+  GRAAL_20_3_3_JAVA_11("20.3.3-java11", new GraalVm20Matcher("20.3.3", "java11")),
+  GRAAL_21_2_0_JAVA_8("21.2.0-java8", new GraalVm21Matcher("21.2.0", "java8")),
+  GRAAL_21_2_0_JAVA_11("21.2.0-java11", new GraalVm21Matcher("21.2.0", "java11")),
+  GRAAL_21_2_0_JAVA_16("21.2.0-java16", new GraalVm21Matcher("21.2.0", "java16")),
+  GRAAL_21_3_0_JAVA_8("21.3.0-java8", new GraalVm21Matcher("21.3.0", "java8")),
+  GRAAL_21_3_0_JAVA_11("21.3.0-java11", new GraalVm21Matcher("21.3.0", "java11")),
+  GRAAL_21_3_0_JAVA_16("21.3.0-java16", new GraalVm21Matcher("21.3.0", "java16")),
+  GRAAL_20_3_4_JAVA_8("20.3.4-java8", new GraalVm20Matcher("20.3.4", "java8")),
+  GRAAL_20_3_4_JAVA_11("20.3.4-java11", new GraalVm20Matcher("20.3.4", "java11")),
   ;
 
   @NotNull final String version;

--- a/src/main/java/org/mikeneck/graalvm/config/ClassUsage.java
+++ b/src/main/java/org/mikeneck/graalvm/config/ClassUsage.java
@@ -57,6 +57,22 @@ public class ClassUsage implements Comparable<ClassUsage>, MergeableConfig<Class
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public Boolean allPublicClasses;
 
+  @Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public Boolean queryAllDeclaredConstructors;
+
+  @Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public Boolean queryAllPublicConstructors;
+
+  @Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public Boolean queryAllDeclaredMethods;
+
+  @Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public Boolean queryAllPublicMethods;
+
   @SuppressWarnings("unused")
   public ClassUsage() {}
 
@@ -71,7 +87,11 @@ public class ClassUsage implements Comparable<ClassUsage>, MergeableConfig<Class
       @Nullable Boolean allPublicConstructors,
       @Nullable Boolean allPublicFields,
       @Nullable Boolean allDeclaredClasses,
-      @Nullable Boolean allPublicClasses) {
+      @Nullable Boolean allPublicClasses,
+      @Nullable Boolean queryAllDeclaredConstructors,
+      @Nullable Boolean queryAllPublicConstructors,
+      @Nullable Boolean queryAllDeclaredMethods,
+      @Nullable Boolean queryAllPublicMethods) {
     this.name = name;
     this.methods = methods;
     this.fields = fields;
@@ -83,6 +103,10 @@ public class ClassUsage implements Comparable<ClassUsage>, MergeableConfig<Class
     this.allPublicFields = allPublicFields;
     this.allDeclaredClasses = allDeclaredClasses;
     this.allPublicClasses = allPublicClasses;
+    this.queryAllDeclaredConstructors = queryAllDeclaredConstructors;
+    this.queryAllPublicConstructors = queryAllPublicConstructors;
+    this.queryAllDeclaredMethods = queryAllDeclaredMethods;
+    this.queryAllPublicMethods = queryAllPublicMethods;
   }
 
   public ClassUsage(
@@ -180,7 +204,11 @@ public class ClassUsage implements Comparable<ClassUsage>, MergeableConfig<Class
         && Objects.equals(allPublicConstructors, that.allPublicConstructors)
         && Objects.equals(allPublicFields, that.allPublicFields)
         && Objects.equals(allDeclaredClasses, that.allDeclaredClasses)
-        && Objects.equals(allPublicClasses, that.allPublicClasses);
+        && Objects.equals(allPublicClasses, that.allPublicClasses)
+        && Objects.equals(queryAllDeclaredConstructors, that.queryAllDeclaredConstructors)
+        && Objects.equals(queryAllPublicConstructors, that.queryAllPublicConstructors)
+        && Objects.equals(queryAllDeclaredMethods, that.queryAllDeclaredMethods)
+        && Objects.equals(queryAllPublicMethods, that.queryAllPublicMethods);
   }
 
   @Override
@@ -196,7 +224,11 @@ public class ClassUsage implements Comparable<ClassUsage>, MergeableConfig<Class
         allPublicConstructors,
         allPublicFields,
         allDeclaredClasses,
-        allPublicClasses);
+        allPublicClasses,
+        queryAllDeclaredConstructors,
+        queryAllPublicConstructors,
+        queryAllDeclaredMethods,
+        queryAllPublicMethods);
   }
 
   @SuppressWarnings("StringBufferReplaceableByString")
@@ -214,6 +246,10 @@ public class ClassUsage implements Comparable<ClassUsage>, MergeableConfig<Class
     sb.append(", allPublicFields=").append(allPublicFields);
     sb.append(", allDeclaredClasses=").append(allDeclaredClasses);
     sb.append(", allPublicClasses=").append(allPublicClasses);
+    sb.append(", queryAllDeclaredConstructors=").append(queryAllDeclaredConstructors);
+    sb.append(", queryAllPublicConstructors=").append(queryAllPublicConstructors);
+    sb.append(", queryAllDeclaredMethods=").append(queryAllDeclaredMethods);
+    sb.append(", queryAllPublicMethods=").append(queryAllPublicMethods);
     sb.append('}');
     return sb.toString();
   }
@@ -243,6 +279,10 @@ public class ClassUsage implements Comparable<ClassUsage>, MergeableConfig<Class
         BooleanMergeable.mergeBoolean(this.allPublicConstructors, other.allPublicConstructors),
         BooleanMergeable.mergeBoolean(this.allPublicFields, other.allPublicFields),
         BooleanMergeable.mergeBoolean(this.allDeclaredClasses, other.allDeclaredClasses),
-        BooleanMergeable.mergeBoolean(this.allPublicClasses, other.allPublicClasses));
+        BooleanMergeable.mergeBoolean(this.allPublicClasses, other.allPublicClasses),
+        BooleanMergeable.mergeBoolean(this.queryAllDeclaredConstructors, other.queryAllDeclaredConstructors),
+        BooleanMergeable.mergeBoolean(this.queryAllPublicConstructors, other.queryAllPublicConstructors),
+        BooleanMergeable.mergeBoolean(this.queryAllDeclaredMethods, other.queryAllDeclaredMethods),
+        BooleanMergeable.mergeBoolean(this.queryAllPublicMethods, other.queryAllPublicMethods));
   }
 }


### PR DESCRIPTION
In the [official document](https://www.graalvm.org/reference-manual/native-image/Reflection/) there are four new fields described. This PR adds them into the `ClassUsage` class, to resolve exceptions reported as #177.

Note that this change is not enough to fully support version `21.3.0`.
Some test cases still fail caused by exceptions like below, and I found no solution:

```
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize instance of `org.mikeneck.graalvm.config.ProxyUsage<java.lang.String>` out of START_OBJECT token
 at [Source: (BufferedReader); line: 2, column: 3] (through reference chain: org.mikeneck.graalvm.config.ProxyConfig[0])
	at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:59)
	at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1468)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1242)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1148)
	at com.fasterxml.jackson.databind.deser.std.StringCollectionDeserializer.handleNonArray(StringCollectionDeserializer.java:274)
	at com.fasterxml.jackson.databind.deser.std.StringCollectionDeserializer.deserialize(StringCollectionDeserializer.java:183)
	at com.fasterxml.jackson.databind.deser.std.StringCollectionDeserializer.deserialize(StringCollectionDeserializer.java:173)
	at com.fasterxml.jackson.databind.deser.std.StringCollectionDeserializer.deserialize(StringCollectionDeserializer.java:21)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:291)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:250)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:27)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4524)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3479)
	at org.mikeneck.graalvm.config.task.DefaultMergeConfigFileWork.readAllFromInputFiles(DefaultMergeConfigFileWork.java:67)
```