### PR TITLE
More changes to support GraalVM 21.3.0

### DIFF
--- a/src/main/java/org/mikeneck/graalvm/config/ClassUsage.java
+++ b/src/main/java/org/mikeneck/graalvm/config/ClassUsage.java
@@ -57,6 +57,26 @@ public class ClassUsage implements Comparable<ClassUsage>, MergeableConfig<Class
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public Boolean allPublicClasses;
 
+  @Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public Boolean queryAllDeclaredConstructors;
+
+  @Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public Boolean queryAllPublicConstructors;
+
+  @Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public Boolean queryAllDeclaredMethods;
+
+  @Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public Boolean queryAllPublicMethods;
+
+  @Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public SortedSet<MethodUsage> queriedMethods = Collections.emptySortedSet();
+
   @SuppressWarnings("unused")
   public ClassUsage() {}
 
@@ -71,7 +91,12 @@ public class ClassUsage implements Comparable<ClassUsage>, MergeableConfig<Class
       @Nullable Boolean allPublicConstructors,
       @Nullable Boolean allPublicFields,
       @Nullable Boolean allDeclaredClasses,
-      @Nullable Boolean allPublicClasses) {
+      @Nullable Boolean allPublicClasses,
+      @Nullable Boolean queryAllDeclaredConstructors,
+      @Nullable Boolean queryAllPublicConstructors,
+      @Nullable Boolean queryAllDeclaredMethods,
+      @Nullable Boolean queryAllPublicMethods,
+      @Nullable SortedSet<MethodUsage> queriedMethods) {
     this.name = name;
     this.methods = methods;
     this.fields = fields;
@@ -83,6 +108,11 @@ public class ClassUsage implements Comparable<ClassUsage>, MergeableConfig<Class
     this.allPublicFields = allPublicFields;
     this.allDeclaredClasses = allDeclaredClasses;
     this.allPublicClasses = allPublicClasses;
+    this.queryAllDeclaredConstructors = queryAllDeclaredConstructors;
+    this.queryAllPublicConstructors = queryAllPublicConstructors;
+    this.queryAllDeclaredMethods = queryAllDeclaredMethods;
+    this.queryAllPublicMethods = queryAllPublicMethods;
+    this.queriedMethods = queriedMethods;
   }
 
   public ClassUsage(
@@ -180,7 +210,12 @@ public class ClassUsage implements Comparable<ClassUsage>, MergeableConfig<Class
         && Objects.equals(allPublicConstructors, that.allPublicConstructors)
         && Objects.equals(allPublicFields, that.allPublicFields)
         && Objects.equals(allDeclaredClasses, that.allDeclaredClasses)
-        && Objects.equals(allPublicClasses, that.allPublicClasses);
+        && Objects.equals(allPublicClasses, that.allPublicClasses)
+        && Objects.equals(queryAllDeclaredConstructors, that.queryAllDeclaredConstructors)
+        && Objects.equals(queryAllPublicConstructors, that.queryAllPublicConstructors)
+        && Objects.equals(queryAllDeclaredMethods, that.queryAllDeclaredMethods)
+        && Objects.equals(queryAllPublicMethods, that.queryAllPublicMethods)
+        && Objects.equals(queriedMethods, that.queriedMethods);
   }
 
   @Override
@@ -196,7 +231,12 @@ public class ClassUsage implements Comparable<ClassUsage>, MergeableConfig<Class
         allPublicConstructors,
         allPublicFields,
         allDeclaredClasses,
-        allPublicClasses);
+        allPublicClasses,
+        queryAllDeclaredConstructors,
+        queryAllPublicConstructors,
+        queryAllDeclaredMethods,
+        queryAllPublicMethods,
+        queriedMethods);
   }
 
   @SuppressWarnings("StringBufferReplaceableByString")
@@ -214,6 +254,11 @@ public class ClassUsage implements Comparable<ClassUsage>, MergeableConfig<Class
     sb.append(", allPublicFields=").append(allPublicFields);
     sb.append(", allDeclaredClasses=").append(allDeclaredClasses);
     sb.append(", allPublicClasses=").append(allPublicClasses);
+    sb.append(", queryAllDeclaredConstructors=").append(queryAllDeclaredConstructors);
+    sb.append(", queryAllPublicConstructors=").append(queryAllPublicConstructors);
+    sb.append(", queryAllDeclaredMethods=").append(queryAllDeclaredMethods);
+    sb.append(", queryAllPublicMethods=").append(queryAllPublicMethods);
+    sb.append(", queriedMethods=").append(queriedMethods);
     sb.append('}');
     return sb.toString();
   }
@@ -232,6 +277,13 @@ public class ClassUsage implements Comparable<ClassUsage>, MergeableConfig<Class
     TreeSet<MethodUsage> newMethods = new TreeSet<>(this.methods);
     newMethods.addAll(other.methods);
     FieldUsages newFields = this.fields.mergeWith(other.fields);
+    TreeSet<MethodUsage> newQueriedMethods = new TreeSet<>();
+    if (this.queriedMethods != null) {
+      newQueriedMethods.addAll(this.queriedMethods);
+    }
+    if (other.queriedMethods != null) {
+      newQueriedMethods.addAll(other.queriedMethods);
+    }
     return new ClassUsage(
         this.name,
         newMethods,
@@ -243,6 +295,13 @@ public class ClassUsage implements Comparable<ClassUsage>, MergeableConfig<Class
         BooleanMergeable.mergeBoolean(this.allPublicConstructors, other.allPublicConstructors),
         BooleanMergeable.mergeBoolean(this.allPublicFields, other.allPublicFields),
         BooleanMergeable.mergeBoolean(this.allDeclaredClasses, other.allDeclaredClasses),
-        BooleanMergeable.mergeBoolean(this.allPublicClasses, other.allPublicClasses));
+        BooleanMergeable.mergeBoolean(this.allPublicClasses, other.allPublicClasses),
+        BooleanMergeable.mergeBoolean(
+            this.queryAllDeclaredConstructors, other.queryAllDeclaredConstructors),
+        BooleanMergeable.mergeBoolean(
+            this.queryAllPublicConstructors, other.queryAllPublicConstructors),
+        BooleanMergeable.mergeBoolean(this.queryAllDeclaredMethods, other.queryAllDeclaredMethods),
+        BooleanMergeable.mergeBoolean(this.queryAllPublicMethods, other.queryAllPublicMethods),
+        newQueriedMethods);
   }
 }

--- a/src/main/java/org/mikeneck/graalvm/config/ProxyUsage.java
+++ b/src/main/java/org/mikeneck/graalvm/config/ProxyUsage.java
@@ -1,11 +1,20 @@
 package org.mikeneck.graalvm.config;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.TreeSet;
 import org.jetbrains.annotations.NotNull;
 
+@JsonDeserialize(using = ProxyUsage.ProxyUsageDeserializer.class)
 public class ProxyUsage extends TreeSet<String> implements Comparable<ProxyUsage> {
 
   public ProxyUsage() {
@@ -44,5 +53,32 @@ public class ProxyUsage extends TreeSet<String> implements Comparable<ProxyUsage
       }
     }
     return thatIterator.hasNext() ? -1 : 0;
+  }
+
+  static class ProxyUsageDeserializer extends JsonDeserializer {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+      String[] interfaces =
+          mapper
+              .readerForListOf(String.class)
+              .readValue(findArray(p.getCodec().readTree(p)), String[].class);
+      return new ProxyUsage(interfaces);
+    }
+
+    private ArrayNode findArray(TreeNode tree) {
+      if (tree.isArray()) {
+        return (ArrayNode) tree;
+      }
+      if (tree.isObject()) {
+        // new format from GraalVM 21.3.0
+        TreeNode interfaces = tree.get("interfaces");
+        if (interfaces != null && interfaces.isArray()) {
+          return (ArrayNode) interfaces;
+        }
+      }
+      throw new IllegalArgumentException();
+    }
   }
 }

--- a/src/test/java/org/mikeneck/graalvm/config/ProxyConfigTest.java
+++ b/src/test/java/org/mikeneck/graalvm/config/ProxyConfigTest.java
@@ -111,4 +111,14 @@ class ProxyConfigTest {
 
     assertThat(proxyConfig).isEqualTo(Collections.emptySortedSet());
   }
+
+  /** GraalVM 21.3.0 generates proxy-config in new format */
+  @Test
+  void graal213() throws IOException {
+    try (InputStream inputStream = reader.configJsonResource("config/proxy-config-4.json")) {
+      ProxyConfig proxyConfig = objectMapper.readValue(inputStream, ProxyConfig.class);
+      assertThat(proxyConfig)
+          .contains(new ProxyUsage("com.example.Printer", "com.example.ExitCode"));
+    }
+  }
 }

--- a/src/test/java/org/mikeneck/graalvm/config/ReflectConfigTest.java
+++ b/src/test/java/org/mikeneck/graalvm/config/ReflectConfigTest.java
@@ -6,11 +6,7 @@ import static org.assertj.core.api.Assertions.fail;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
@@ -274,6 +270,26 @@ class ReflectConfigTest {
                           classUsage ->
                               assertThat(classUsage.name).isEqualTo("java.lang.String"))));
       return tests;
+    }
+  }
+
+  /**
+   * GraalVM 21.3.0 added the {@code queriedMethods} field into the class usage
+   *
+   * @see <a
+   *     href="https://medium.com/graalvm/graalvm-21-3-is-here-java-17-native-image-performance-updates-and-more-ac4cbafcfc05"
+   *     >Official example config file</a>
+   */
+  @Test
+  void graal213() throws IOException {
+    ClassUsage expected = new ClassUsage("org.graalvm.Example");
+    expected.queryAllDeclaredConstructors = true;
+    expected.queriedMethods = new TreeSet<>();
+    expected.queriedMethods.add(new MethodUsage("queriedOnlyMethod"));
+
+    try (InputStream inputStream = reader.configJsonResource("config/reflect-config-3.json")) {
+      ReflectConfig reflectConfig = objectMapper.readValue(inputStream, ReflectConfig.class);
+      assertThat(reflectConfig).contains(expected);
     }
   }
 }

--- a/src/test/resources/config/proxy-config-4.json
+++ b/src/test/resources/config/proxy-config-4.json
@@ -1,0 +1,5 @@
+[
+  {
+    "interfaces":["com.example.Printer","com.example.ExitCode"]}
+
+]

--- a/src/test/resources/config/reflect-config-3.json
+++ b/src/test/resources/config/reflect-config-3.json
@@ -1,0 +1,5 @@
+[{
+  "name": "org.graalvm.Example",
+  "queryAllDeclaredConstructors": true,
+  "queriedMethods": [{"name":"queriedOnlyMethod", "parameterTypes":[]}]
+}]


### PR DESCRIPTION
#182 is not enough to support GraalVM 21.3.0, and here is an additional fix.
With these changes, I could run the `nativeImage` task with GraalVM CE 21.3.0 (Java 11) for my project.

Currently, GraalVM provides no document regarding the change in `proxy-config.json`, so I'm asking about it at https://github.com/oracle/graal/issues/4067
In my understanding we can treat it as `oldConfig == newConfig.interfaces`, so I made a fix like this.